### PR TITLE
Fix problem with multiple matching conditions on Bazel 4.0.0

### DIFF
--- a/rules/update_deb_packages.bzl
+++ b/rules/update_deb_packages.bzl
@@ -57,7 +57,6 @@ def update_deb_packages(name, pgp_keys, **kwargs):
             "@bazel_tools//src/conditions:linux_x86_64": Label("@update_deb_packages_linux_amd64//file"),
             "@bazel_tools//src/conditions:windows": Label("@update_deb_packages_windows_amd64//file"),
             "@bazel_tools//src/conditions:darwin_x86_64": Label("@update_deb_packages_darwin_amd64//file"),
-            "@bazel_tools//src/conditions:darwin": Label("@update_deb_packages_darwin_amd64//file"),
         }),
         **kwargs
     )


### PR DESCRIPTION
Hi, and thanks for publishing this repo!

I noticed after upgrading to Bazel 4.0.0 that I started getting these errors:

```
Illegal ambiguous match on configurable attribute "update_deb_packages_exec" in //:update_deb_pkgs_buster_amd64_script:
@bazel_tools//src/conditions:darwin_x86_64
@bazel_tools//src/conditions:darwin
Multiple matches are not allowed unless one is unambiguously more specialized.
```

Removing the `conditions:darwin` appears to fix this.