### PR TITLE
Add templating to URLs for downloading package and minor improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ load("@rules_deb_packages//:deb_packages.bzl", "deb_packages")
 deb_packages(
     name = "debian_buster_amd64",
     arch = "amd64",
-    mirrors = [
-        "http://deb.debian.org/debian",
-        "http://deb.debian.org/debian-security",
-    ],
     packages = {
         "base-files": "pool/main/b/base-files/base-files_10.3+deb10u8_amd64.deb",
         "busybox": "pool/main/b/busybox/busybox_1.30.1-4_amd64.deb",
@@ -58,6 +54,13 @@ deb_packages(
         "http://deb.debian.org/debian buster main",
         "http://deb.debian.org/debian buster-updates main",
         "http://deb.debian.org/debian-security buster/updates main",
+    ],
+    timestamp = "20210216T115751Z",
+    urls = [
+        "http://deb.debian.org/debian/$(package_path)",
+        "http://deb.debian.org/debian-security/$(package_path)",
+        "https://snapshot.debian.org/archive/debian/$(timestamp)/$(package_path)",  # Needed in case of supersed archive no more available on the mirrors
+        "https://snapshot.debian.org/archive/debian-security/$(timestamp)/$(package_path)",  # Needed in case of supersed archive no more available on the mirrors
     ],
 )
 ```
@@ -142,10 +145,6 @@ Next create a `deb_packages` rule in your WORKSPACE file without any packages de
 deb_packages(
     name = "debian_buster_amd64",
     arch = "amd64",
-    mirrors = [
-        "http://deb.debian.org/debian",
-        "http://deb.debian.org/debian-security",
-    ],
     packages = {
         "base-files": "",
         "busybox": "",
@@ -158,6 +157,13 @@ deb_packages(
         "http://deb.debian.org/debian buster main",
         "http://deb.debian.org/debian buster-updates main",
         "http://deb.debian.org/debian-security buster/updates main",
+    ],
+    timestamp = "20210216T115751Z",
+    urls = [
+        "http://deb.debian.org/debian/$(package_path)",
+        "http://deb.debian.org/debian-security/$(package_path)",
+        "https://snapshot.debian.org/archive/debian/$(timestamp)/$(package_path)",  # Needed in case of supersed archive no more available on the mirrors
+        "https://snapshot.debian.org/archive/debian-security/$(timestamp)/$(package_path)",  # Needed in case of supersed archive no more available on the mirrors
     ],
 )
 ```
@@ -210,16 +216,19 @@ Now enter this information in the `WORKSPACE` file in a `deb_packages` rule:
 deb_packages(
     name = "my_new_manual_source",
     arch = "amd64",
-    mirrors = [
-        "http://deb.debian.org/debian",
-        "http://my.private.mirror/debian",
-    ],
-    packages = {
+        packages = {
         "libpython2.7-minimal": "pool/main/p/python2.7/libpython2.7-minimal_2.7.9-2+deb8u1_amd64.deb",
     },
     packages_sha256 = {
         "libpython2.7-minimal": "916e2c541aa954239cb8da45d1d7e4ecec232b24d3af8982e76bf43d3e1758f3",
     },
+    timestamp = "20210216T115751Z",
+    urls = [
+        "http://deb.debian.org/debian/$(package_path)",
+        "http://deb.debian.org/debian-security/$(package_path)",
+        "https://snapshot.debian.org/archive/debian/$(timestamp)/$(package_path)",  # Needed in case of supersed archive no more available on the mirrors
+        "https://snapshot.debian.org/archive/debian-security/$(timestamp)/$(package_path)",  # Needed in case of supersed archive no more available on the mirrors
+    ],
 )
 ```
 
@@ -266,11 +275,17 @@ Every key name in the `packages` section must exactly match a key name in the `p
       </td>
     </tr>
     <tr>
-      <td><code>mirrors</code></td>
+      <td><code>urls</code></td>
       <td>
         <p><code>the full url of the package repository, required</code></p>
-        <p>All of these mirrors are expected to host a Debian style mirror and to host the same versions of files</p>
-        <p>Many mirrors host their packages in a subdirectory (e.g. <code>http://deb.debian.org/debian</code> instead of <code>http://deb.debian.org</code>), in that case use the former URL.</p>
+        <p>We need the full url needed for accessing the required deb package files.</p>
+        <p>These urls can be based on debian or ubuntu mirrors and support templating with the following variables :</p>
+        <p>
+          <li>$(package_path) : will be replaced with the full package path, eg : pool/main/b/base-files/base-files_10.3+deb10u8_amd64.deb</li>
+          <li>$(package_name) : will be replaced with the package name (after the last '/' of the package path), eg: base-files_10.3+deb10u8_amd64.deb</li>
+          <li>$(timestamp) : will be replaced wit he timestamp attribute value, eg : 20210216T115751Z</li>
+        </p>
+        <p>e.g. <code>https://snapshot.debian.org/archive/debian-security/$(timestamp)/$(package_path)</code></p>
       </td>
     </tr>
     <tr>
@@ -294,6 +309,13 @@ Every key name in the `packages` section must exactly match a key name in the `p
       <td>
         <p><code>a list of full sources of the package repository in format similar to apt sources.list without the deb prefix</code></p>
         <p>e.g. <code>'http://deb.debian.org/debian buster main'</code></p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>timestamp</code></td>
+      <td>
+        <p><code>timestamp of the last update (format : 'yyyyMMddTHHmmssZ'), required</code></p>
+        <p>e.g. 20210216T115751Z</p>
       </td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Every key name in the `packages` section must exactly match a key name in the `p
     <tr>
       <td><code>timestamp</code></td>
       <td>
-        <p><code>timestamp of the last update (format : 'yyyyMMddTHHmmssZ'), required</code></p>
+        <p><code>timestamp of the last update (format : 'yyyyMMddTHHmmssZ'), not mandatory</code></p>
         <p>e.g. 20210216T115751Z</p>
       </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Now enter this information in the `WORKSPACE` file in a `deb_packages` rule:
 deb_packages(
     name = "my_new_manual_source",
     arch = "amd64",
-        packages = {
+    packages = {
         "libpython2.7-minimal": "pool/main/p/python2.7/libpython2.7-minimal_2.7.9-2+deb8u1_amd64.deb",
     },
     packages_sha256 = {

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -4,9 +4,11 @@ update_deb_packages(
     name = "update_deb_packages",
     bzl_files = [
         "debian_buster_amd64.bzl",
+        "ubuntu_bionic_amd64.bzl",
     ],
     pgp_keys = [
         "@buster_archive_key//file",
         "@buster_security_archive_key//file",
+        "@ubuntu_key//file",
     ],
 )

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -26,7 +26,7 @@ pip_deps()
 # Example for using the deb_packages ruleset
 http_archive(
     name = "rules_deb_packages",
-    sha256 = "dc729b64a429e6670edefffa0fa917730552c01fd414bd161d9138b5ec04b9de",
+    sha256 = "1ab1e6cc1f55e2b01b23a4ad8e1652e4e1317df6a09ae872ebe0fa1dbbb6504e",
     urls = ["https://github.com/petermylemans/rules_deb_packages/releases/download/v0.3.0/rules_deb_packages.tar.gz"],
 )
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -26,7 +26,7 @@ pip_deps()
 # Example for using the deb_packages ruleset
 http_archive(
     name = "rules_deb_packages",
-    sha256 = "1ab1e6cc1f55e2b01b23a4ad8e1652e4e1317df6a09ae872ebe0fa1dbbb6504e",
+    sha256 = "28976022963fe8045e6a2c71e080cac75726b4f0a161e223217a7b6e75190cf8",
     urls = ["https://github.com/petermylemans/rules_deb_packages/releases/download/v0.3.0/rules_deb_packages.tar.gz"],
 )
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -120,7 +120,6 @@ deb_packages(
         "http://us.archive.ubuntu.com/ubuntu bionic-backports main",
         "http://security.ubuntu.com/ubuntu bionic-security main universe",
     ],
-    timestamp = "20210216T113505Z",
     urls = [
         "http://us.archive.ubuntu.com/ubuntu/$(package_path)",
         "http://security.ubuntu.com/ubuntu/$(package_path)",

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -26,7 +26,7 @@ pip_deps()
 # Example for using the deb_packages ruleset
 http_archive(
     name = "rules_deb_packages",
-    sha256 = "d46a7ff31862c35a55deaf81ec0ba2f42233925ac9b7d6f84cd123915d0a540b",
+    sha256 = "dc729b64a429e6670edefffa0fa917730552c01fd414bd161d9138b5ec04b9de",
     urls = ["https://github.com/petermylemans/rules_deb_packages/releases/download/v0.3.0/rules_deb_packages.tar.gz"],
 )
 
@@ -48,15 +48,15 @@ http_file(
     urls = ["https://ftp-master.debian.org/keys/archive-key-10-security.asc"],
 )
 
+http_file(
+    name = "ubuntu_key",
+    sha256 = "50a57221cf2bedcaafb8a6a73f29ed71f153a30deae3ee7076dc2b9220e11cf0",
+    urls = ["https://keyserver.ubuntu.com/pks/lookup?op=hget&search=12120bd49c566eaf49d31f267ec0b900"],
+)
+
 deb_packages(
     name = "debian_buster_amd64",
     arch = "amd64",
-    urls = [
-            "http://deb.debian.org/debian/$(package_path)",
-            "http://deb.debian.org/debian-security/$(package_path)",
-            "https://snapshot.debian.org/archive/debian/$(timestamp)/$(package_path)",
-            "https://snapshot.debian.org/archive/debian-security/$(timestamp)/$(package_path)",
-        ],
     packages = {
         "base-files": "pool/main/b/base-files/base-files_10.3+deb10u8_amd64.deb",
         "busybox": "pool/main/b/busybox/busybox_1.30.1-4_amd64.deb",
@@ -82,5 +82,48 @@ deb_packages(
         "http://deb.debian.org/debian buster-updates main",
         "http://deb.debian.org/debian-security buster/updates main",
     ],
-    timestamp = "20210215T214317Z",
+    timestamp = "20210216T115751Z",
+    urls = [
+        "http://deb.debian.org/debian/$(package_path)",
+        "http://deb.debian.org/debian-security/$(package_path)",
+        "https://snapshot.debian.org/archive/debian/$(timestamp)/$(package_path)",  # Needed in case of supersed archive no more available on the mirrors
+        "https://snapshot.debian.org/archive/debian-security/$(timestamp)/$(package_path)",  # Needed in case of supersed archive no more available on the mirrors
+    ],
+)
+
+deb_packages(
+    name = "ubuntu_bionic_amd64",
+    arch = "amd64",
+    packages = {
+        "base-files": "pool/main/b/base-files/base-files_10.1ubuntu2.10_amd64.deb",
+        "busybox": "pool/universe/b/busybox/busybox_1.27.2-2ubuntu3.3_amd64.deb",
+        "ca-certificates": "pool/main/c/ca-certificates/ca-certificates_20210119~18.04.1_all.deb",
+        "libc6": "pool/main/g/glibc/libc6_2.27-3ubuntu1.4_amd64.deb",
+        "libssl1.1": "pool/main/o/openssl/libssl1.1_1.1.1-1ubuntu2.1~18.04.7_amd64.deb",
+        "netbase": "pool/main/n/netbase/netbase_5.4_all.deb",
+        "openssl": "pool/main/o/openssl/openssl_1.1.1-1ubuntu2.1~18.04.7_amd64.deb",
+        "tzdata": "pool/main/t/tzdata/tzdata_2021a-0ubuntu0.18.04_all.deb",
+    },
+    packages_sha256 = {
+        "base-files": "9abf6982e61cabc44011247b8a39af39bf47cdb96cd12d898bf47b3ebe92a80e",
+        "busybox": "a1b5ea4a7eb95fe3cadca78406af57c9bdb3b024d5060400fdff5344179ab1b0",
+        "ca-certificates": "0eef06ee5c975fdf029b7b26d12701441cfd22c556927772b236f2bc5b39cc2e",
+        "libc6": "46d39b8965f35457ce5db62662832c095fd7e01e72093da99ae025eb8e12bbe5",
+        "libssl1.1": "6cba7ab11adfe998afb8a1c1b85bf1cb0449101cb4160402bac2507ccc72b632",
+        "netbase": "cbda1c8035cd1fe0b1fb09b456892c0bb868657bfe02da82f0b16207d391145e",
+        "openssl": "26eec06c925b5468e8c80cd0645c62e0ff613e60a074e5bf92dd9df127f67660",
+        "tzdata": "7a28ea35faffb239a92f8f4ee204d64d5bec2ad308b04118d046334f44152e02",
+    },
+    sources = [
+        "http://us.archive.ubuntu.com/ubuntu bionic main",
+        "http://us.archive.ubuntu.com/ubuntu bionic-updates main",
+        "http://us.archive.ubuntu.com/ubuntu bionic-backports main",
+        "http://security.ubuntu.com/ubuntu bionic-security main universe",
+    ],
+    timestamp = "20210216T113505Z",
+    urls = [
+        "http://us.archive.ubuntu.com/ubuntu/$(package_path)",
+        "http://security.ubuntu.com/ubuntu/$(package_path)",
+        "https://launchpad.net/ubuntu/+archive/primary/+files/$(package_file)",  # Needed in case of supersed archive no more available on the mirrors
+    ],
 )

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -51,10 +51,12 @@ http_file(
 deb_packages(
     name = "debian_buster_amd64",
     arch = "amd64",
-    mirrors = [
-        "http://deb.debian.org/debian",
-        "http://deb.debian.org/debian-security",
-    ],
+    urls = [
+            "http://deb.debian.org/debian/$(package_path)",
+            "http://deb.debian.org/debian-security/$(package_path)",
+            "https://snapshot.debian.org/archive/debian/$(timestamp)/$(package_path)",
+            "https://snapshot.debian.org/archive/debian-security/$(timestamp)/$(package_path)",
+        ],
     packages = {
         "base-files": "pool/main/b/base-files/base-files_10.3+deb10u8_amd64.deb",
         "busybox": "pool/main/b/busybox/busybox_1.30.1-4_amd64.deb",
@@ -80,4 +82,5 @@ deb_packages(
         "http://deb.debian.org/debian buster-updates main",
         "http://deb.debian.org/debian-security buster/updates main",
     ],
+    timestamp = "20210215T214317Z",
 )

--- a/examples/deb_packages_base/BUILD
+++ b/examples/deb_packages_base/BUILD
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@debian_buster_amd64//debs:deb_packages.bzl", "debian_buster_amd64")
+load("@ubuntu_bionic_amd64//debs:deb_packages.bzl", "ubuntu_bionic_amd64")
+
 
 container_image(
     name = "base_buster",
@@ -10,6 +12,23 @@ container_image(
         debian_buster_amd64["libc6"],
         debian_buster_amd64["libssl1.1"],
         debian_buster_amd64["busybox"],
+    ],
+    entrypoint = [
+        "busybox",
+        "sh",
+    ],
+    env = {"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+)
+
+container_image(
+    name = "base_bionic",
+    debs = [
+        ubuntu_bionic_amd64["base-files"],
+        ubuntu_bionic_amd64["netbase"],
+        ubuntu_bionic_amd64["tzdata"],
+        ubuntu_bionic_amd64["libc6"],
+        ubuntu_bionic_amd64["libssl1.1"],
+        ubuntu_bionic_amd64["busybox"],
     ],
     entrypoint = [
         "busybox",

--- a/examples/debian_buster_amd64.bzl
+++ b/examples/debian_buster_amd64.bzl
@@ -4,9 +4,11 @@ def debian_buster_amd64():
     deb_packages(
         name = "debian_buster_amd64_macro",
         arch = "amd64",
-        mirrors = [
-            "http://deb.debian.org/debian",
-            "http://deb.debian.org/debian-security",
+        urls = [
+            "http://deb.debian.org/debian/$(package_path)",
+            "http://deb.debian.org/debian-security/$(package_path)",
+            "https://snapshot.debian.org/archive/debian/$(timestamp)/$(package_path)",
+            "https://snapshot.debian.org/archive/debian-security/$(timestamp)/$(package_path)",
         ],
         packages = {
             "base-files": "pool/main/b/base-files/base-files_10.3+deb10u8_amd64.deb",
@@ -33,4 +35,5 @@ def debian_buster_amd64():
             "http://deb.debian.org/debian buster-updates main",
             "http://deb.debian.org/debian-security buster/updates main",
         ],
+        timestamp = "20210215T214319Z",
     )

--- a/examples/debian_buster_amd64.bzl
+++ b/examples/debian_buster_amd64.bzl
@@ -7,8 +7,8 @@ def debian_buster_amd64():
         urls = [
             "http://deb.debian.org/debian/$(package_path)",
             "http://deb.debian.org/debian-security/$(package_path)",
-            "https://snapshot.debian.org/archive/debian/$(timestamp)/$(package_path)",
-            "https://snapshot.debian.org/archive/debian-security/$(timestamp)/$(package_path)",
+            "https://snapshot.debian.org/archive/debian/$(timestamp)/$(package_path)",  # Needed in case of supersed archive no more available on the mirrors
+            "https://snapshot.debian.org/archive/debian-security/$(timestamp)/$(package_path)",  # Needed in case of supersed archive no more available on the mirrors
         ],
         packages = {
             "base-files": "pool/main/b/base-files/base-files_10.3+deb10u8_amd64.deb",
@@ -35,5 +35,5 @@ def debian_buster_amd64():
             "http://deb.debian.org/debian buster-updates main",
             "http://deb.debian.org/debian-security buster/updates main",
         ],
-        timestamp = "20210215T214319Z",
+        timestamp = "20210216T113509Z",
     )

--- a/examples/ubuntu_bionic_amd64.bzl
+++ b/examples/ubuntu_bionic_amd64.bzl
@@ -30,7 +30,6 @@ def ubuntu_bionic_amd64():
             "http://us.archive.ubuntu.com/ubuntu bionic-backports main",
             "http://security.ubuntu.com/ubuntu bionic-security main universe",
         ],
-        timestamp = "20210216T113512Z",
         urls = [
             "http://us.archive.ubuntu.com/ubuntu/$(package_path)",
             "http://security.ubuntu.com/ubuntu/$(package_path)",

--- a/examples/ubuntu_bionic_amd64.bzl
+++ b/examples/ubuntu_bionic_amd64.bzl
@@ -1,0 +1,39 @@
+load("@rules_deb_packages//:deb_packages.bzl", "deb_packages")
+
+def ubuntu_bionic_amd64():
+    deb_packages(
+        name = "ubuntu_bionic_amd64_macro",
+        arch = "amd64",
+        packages = {
+            "base-files": "pool/main/b/base-files/base-files_10.1ubuntu2.10_amd64.deb",
+            "busybox": "pool/universe/b/busybox/busybox_1.27.2-2ubuntu3.3_amd64.deb",
+            "ca-certificates": "pool/main/c/ca-certificates/ca-certificates_20210119~18.04.1_all.deb",
+            "libc6": "pool/main/g/glibc/libc6_2.27-3ubuntu1.4_amd64.deb",
+            "libssl1.1": "pool/main/o/openssl/libssl1.1_1.1.1-1ubuntu2.1~18.04.7_amd64.deb",
+            "netbase": "pool/main/n/netbase/netbase_5.4_all.deb",
+            "openssl": "pool/main/o/openssl/openssl_1.1.1-1ubuntu2.1~18.04.7_amd64.deb",
+            "tzdata": "pool/main/t/tzdata/tzdata_2021a-0ubuntu0.18.04_all.deb",
+        },
+        packages_sha256 = {
+            "base-files": "9abf6982e61cabc44011247b8a39af39bf47cdb96cd12d898bf47b3ebe92a80e",
+            "busybox": "a1b5ea4a7eb95fe3cadca78406af57c9bdb3b024d5060400fdff5344179ab1b0",
+            "ca-certificates": "0eef06ee5c975fdf029b7b26d12701441cfd22c556927772b236f2bc5b39cc2e",
+            "libc6": "46d39b8965f35457ce5db62662832c095fd7e01e72093da99ae025eb8e12bbe5",
+            "libssl1.1": "6cba7ab11adfe998afb8a1c1b85bf1cb0449101cb4160402bac2507ccc72b632",
+            "netbase": "cbda1c8035cd1fe0b1fb09b456892c0bb868657bfe02da82f0b16207d391145e",
+            "openssl": "26eec06c925b5468e8c80cd0645c62e0ff613e60a074e5bf92dd9df127f67660",
+            "tzdata": "7a28ea35faffb239a92f8f4ee204d64d5bec2ad308b04118d046334f44152e02",
+        },
+        sources = [
+            "http://us.archive.ubuntu.com/ubuntu bionic main",
+            "http://us.archive.ubuntu.com/ubuntu bionic-updates main",
+            "http://us.archive.ubuntu.com/ubuntu bionic-backports main",
+            "http://security.ubuntu.com/ubuntu bionic-security main universe",
+        ],
+        timestamp = "20210216T113512Z",
+        urls = [
+            "http://us.archive.ubuntu.com/ubuntu/$(package_path)",
+            "http://security.ubuntu.com/ubuntu/$(package_path)",
+            "https://launchpad.net/ubuntu/+archive/primary/+files/$(package_file)",  # Needed in case of supersed archive no more available on the mirrors
+        ],
+    )

--- a/rules/deb_packages.bzl
+++ b/rules/deb_packages.bzl
@@ -11,12 +11,16 @@ def _deb_packages_impl(repository_ctx):
     package_version_dict = {}
     package_upstream_version_dict = {}
     timestamp = repository_ctx.attr.timestamp
+
+    # check that $(timestamp) is not present in the url if the timestamp attribute is not defined 
+    for url in repository_ctx.attr.urls:
+        if timestamp == "":
+            if url.find("$(timestamp)") != -1:
+                fail("Timestamp attribute is not defined but required for the following url : %s" % (url))
+
     for package in repository_ctx.attr.packages:
         urllist = []
         for url in repository_ctx.attr.urls:
-            if timestamp == "":
-                if url.find("$(timestamp)") != -1:
-                    fail("Timestamp attribute is not defined but required for the following url : %s" % (url))
             urllist.append(url.replace("$(timestamp)",timestamp).replace("$(package_path)", repository_ctx.attr.packages[package]).replace("$(package_file)", repository_ctx.attr.packages[package].rpartition("/")[2]))
         repository_ctx.download(
             urllist,

--- a/rules/deb_packages.bzl
+++ b/rules/deb_packages.bzl
@@ -14,7 +14,7 @@ def _deb_packages_impl(repository_ctx):
     for package in repository_ctx.attr.packages:
         urllist = []
         for url in repository_ctx.attr.urls:
-            urllist.append(urls.replace("$(timestamp)",timestamp).replace("$(package_path)", repository_ctx.attr.packages[package]).replace("$(package_file)", repository_ctx.attr.packages[package].rpartition("/")[2]))
+            urllist.append(url.replace("$(timestamp)",timestamp).replace("$(package_path)", repository_ctx.attr.packages[package]).replace("$(package_file)", repository_ctx.attr.packages[package].rpartition("/")[2]))
         repository_ctx.download(
             urllist,
             output = "debs/" + repository_ctx.attr.packages_sha256[package] + ".deb",

--- a/rules/deb_packages.bzl
+++ b/rules/deb_packages.bzl
@@ -14,6 +14,9 @@ def _deb_packages_impl(repository_ctx):
     for package in repository_ctx.attr.packages:
         urllist = []
         for url in repository_ctx.attr.urls:
+            if timestamp == "":
+                if url.find("$(timestamp)") != -1:
+                    fail("Timestamp attribute is not defined but required for the following url : %s" % (url))
             urllist.append(url.replace("$(timestamp)",timestamp).replace("$(package_path)", repository_ctx.attr.packages[package]).replace("$(package_file)", repository_ctx.attr.packages[package].rpartition("/")[2]))
         repository_ctx.download(
             urllist,

--- a/rules/deb_packages.bzl
+++ b/rules/deb_packages.bzl
@@ -10,6 +10,7 @@ def _deb_packages_impl(repository_ctx):
     package_rule_dict = {}
     package_version_dict = {}
     package_upstream_version_dict = {}
+    timestamp = repository_ctx.attr.timestamp
     for package in repository_ctx.attr.packages:
         urllist = []
         for mirror in repository_ctx.attr.mirrors:
@@ -18,6 +19,7 @@ def _deb_packages_impl(repository_ctx):
                 urllist.append(mirror + repository_ctx.attr.packages[package])
             else:
                 urllist.append(mirror + "/" + repository_ctx.attr.packages[package])
+        urllist.append("https://snapshot.debian.org/archive/debian/" + timestamp + "/" + repository_ctx.attr.packages[package])
         repository_ctx.download(
             urllist,
             output = "debs/" + repository_ctx.attr.packages_sha256[package] + ".deb",
@@ -53,6 +55,9 @@ _deb_packages = repository_rule(
     attrs = {
         "arch": attr.string(
             doc = "the target package architecture, required - e.g. arm64 or amd64",
+        ),
+        "timestamp": attr.string(
+            doc = "the timestamp value of the archive lookup (yyyyMMddTHHmmssZ), required - e.g. 20091004T111800Z",
         ),
         "packages": attr.string_dict(
             doc = "a dictionary mapping packagename to package_path, required - e.g. {\"foo\":\"pool/main/f/foo/foo_1.2.3-0_amd64.deb\"}",

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -17,7 +17,7 @@ def deb_packages_dependencies():
             name = "update_deb_packages_darwin_amd64",
             executable = True,
             urls = ["https://github.com/petermylemans/rules_deb_packages/releases/download/v0.3.0/update_deb_packages_darwin_amd64"],
-            sha256 = "c6b353a331201615f9cad0d0a13c71f8330b4468ffa0ebf4574d3ab4563aa240",
+            sha256 = "589090e63d51234526bc3b5edd3b681a50d2441dd4ebf9366b1c618b633fe010",
         )
 
     if "update_deb_packages_linux_amd64" not in excludes:
@@ -25,7 +25,7 @@ def deb_packages_dependencies():
             name = "update_deb_packages_linux_amd64",
             executable = True,
             urls = ["https://github.com/petermylemans/rules_deb_packages/releases/download/v0.3.0/update_deb_packages_linux_amd64"],
-            sha256 = "d7f118027c24ca49d4f1d2572c858620b3ac2b61152edc5c32945a063a0c353d",
+            sha256 = "8b58ab7f0f89ec58a8279648a8d9da87c7172de751d409e27a144dc7ef96d09e",
         )
 
     if "update_deb_packages_linux_arm64" not in excludes:
@@ -33,7 +33,7 @@ def deb_packages_dependencies():
             name = "update_deb_packages_linux_arm64",
             executable = True,
             urls = ["https://github.com/petermylemans/rules_deb_packages/releases/download/v0.3.0/update_deb_packages_linux_arm64"],
-            sha256 = "7b4736bc07309d5712f95903889181a4c1a89c74d2ee91ea1e324fc51df0eda4",
+            sha256 = "e2f4e9376aacea9e40b4169aaf3e2edeff5aaf9480fc695891c1f7692d2b13af",
         )
 
     if "update_deb_packages_windows_amd64" not in excludes:
@@ -41,5 +41,5 @@ def deb_packages_dependencies():
             name = "update_deb_packages_windows_amd64",
             executable = True,
             urls = ["https://github.com/petermylemans/rules_deb_packages/releases/download/v0.3.0/update_deb_packages_windows_amd64.exe"],
-            sha256 = "65a7dbeea67aa7707ea6e679903e2929b4bb7ca4f31d691edeed47b83d523316",
+            sha256 = "f9f7f31459c3ec5ba096de230911cb664f9337b07ac25233b8ff4fa8d3283983",
         )

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -17,7 +17,7 @@ def deb_packages_dependencies():
             name = "update_deb_packages_darwin_amd64",
             executable = True,
             urls = ["https://github.com/petermylemans/rules_deb_packages/releases/download/v0.3.0/update_deb_packages_darwin_amd64"],
-            sha256 = "589090e63d51234526bc3b5edd3b681a50d2441dd4ebf9366b1c618b633fe010",
+            sha256 = "020d4b963ac403b0e5e25f8a65bbf8011ba85e0fad453772b52f9a520b281fef",
         )
 
     if "update_deb_packages_linux_amd64" not in excludes:
@@ -25,7 +25,7 @@ def deb_packages_dependencies():
             name = "update_deb_packages_linux_amd64",
             executable = True,
             urls = ["https://github.com/petermylemans/rules_deb_packages/releases/download/v0.3.0/update_deb_packages_linux_amd64"],
-            sha256 = "8b58ab7f0f89ec58a8279648a8d9da87c7172de751d409e27a144dc7ef96d09e",
+            sha256 = "bebd5b29baf09b7e5a06e324b929b64ee820b907a95b080752c1b7b39b81ea24",
         )
 
     if "update_deb_packages_linux_arm64" not in excludes:
@@ -33,7 +33,7 @@ def deb_packages_dependencies():
             name = "update_deb_packages_linux_arm64",
             executable = True,
             urls = ["https://github.com/petermylemans/rules_deb_packages/releases/download/v0.3.0/update_deb_packages_linux_arm64"],
-            sha256 = "e2f4e9376aacea9e40b4169aaf3e2edeff5aaf9480fc695891c1f7692d2b13af",
+            sha256 = "a52a0b6599ccda21a733cfdd0d2f6a2fac37a516eca960541859f70fe18d7da3",
         )
 
     if "update_deb_packages_windows_amd64" not in excludes:
@@ -41,5 +41,5 @@ def deb_packages_dependencies():
             name = "update_deb_packages_windows_amd64",
             executable = True,
             urls = ["https://github.com/petermylemans/rules_deb_packages/releases/download/v0.3.0/update_deb_packages_windows_amd64.exe"],
-            sha256 = "f9f7f31459c3ec5ba096de230911cb664f9337b07ac25233b8ff4fa8d3283983",
+            sha256 = "2b9fb89f11f01c82231fa156fb27ab082a8459eccf7822e481753f7e2eda015a",
         )

--- a/tools/update_deb_packages/update_deb_packages.go
+++ b/tools/update_deb_packages/update_deb_packages.go
@@ -288,7 +288,7 @@ func updateWorkspaceRule(keyring openpgp.EntityList, rule *build.Rule) {
 	sort.Strings(packageNames)
 
 	packageShaNames := make([]string, 0, len(packagesSha256))
-	for p := range packages {
+	for p := range packagesSha256 {
 		packageShaNames = append(packageShaNames, p)
 	}
 	sort.Strings(packageShaNames)
@@ -321,7 +321,6 @@ func updateWorkspaceRule(keyring openpgp.EntityList, rule *build.Rule) {
 	newPackages := make(map[string]string)
 	newPackagesSha256 := make(map[string]string)
 
-	updated := false
 	for _, pack := range packageNames {
 		packlist := strings.Split(pack, "=")
 		var packname string
@@ -352,7 +351,6 @@ func updateWorkspaceRule(keyring openpgp.EntityList, rule *build.Rule) {
 						newPackagesSha256[pack] = pkg.SHA256
 						targetVersion = currentVersion
 						done = true
-						updated = true
 					}
 				} else {
 					// version is fixed, break once found
@@ -360,7 +358,6 @@ func updateWorkspaceRule(keyring openpgp.EntityList, rule *build.Rule) {
 						newPackages[pack] = pkg.Filename
 						newPackagesSha256[pack] = pkg.SHA256
 						done = true
-						updated = true
 						break
 					}
 				}
@@ -377,7 +374,7 @@ func updateWorkspaceRule(keyring openpgp.EntityList, rule *build.Rule) {
 		newPackagesKV = append(newPackagesKV, &build.KeyValueExpr{Key: &build.StringExpr{Value: pkgName}, Value: &build.StringExpr{Value: newPackages[pkgName]}})
 		newPackagesSha256KV = append(newPackagesSha256KV, &build.KeyValueExpr{Key: &build.StringExpr{Value: pkgName}, Value: &build.StringExpr{Value: newPackagesSha256[pkgName]}})
 	}
-	if updated == true {
+	if reflect.DeepEqual(packagesSha256, newPackagesSha256) == false {
 		timestamp = fmt.Sprintf("%d%02d%02dT%02d%02d%02dZ", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
 		rule.SetAttr("timestamp", &build.StringExpr{Value: timestamp})
 	}

--- a/tools/update_deb_packages/update_deb_packages.go
+++ b/tools/update_deb_packages/update_deb_packages.go
@@ -296,7 +296,7 @@ func updateWorkspaceRule(keyring openpgp.EntityList, rule *build.Rule) {
 		log.Fatalf("Mismatch between package names in packages and packages_sha256 in rule %s.\npackages: %s\npackages_sha256: %s", rule.Name(), packageNames, packageShaNames)
 	}
 
-	t := time.Now()
+	t := time.Now().UTC()
 
 	var mirrors = make([]string, 0)
 	var allPackages []control.BinaryIndex
@@ -374,7 +374,7 @@ func updateWorkspaceRule(keyring openpgp.EntityList, rule *build.Rule) {
 		newPackagesKV = append(newPackagesKV, &build.KeyValueExpr{Key: &build.StringExpr{Value: pkgName}, Value: &build.StringExpr{Value: newPackages[pkgName]}})
 		newPackagesSha256KV = append(newPackagesSha256KV, &build.KeyValueExpr{Key: &build.StringExpr{Value: pkgName}, Value: &build.StringExpr{Value: newPackagesSha256[pkgName]}})
 	}
-	if reflect.DeepEqual(packagesSha256, newPackagesSha256) == false {
+	if timestamp != "" && reflect.DeepEqual(packagesSha256, newPackagesSha256) == false {
 		timestamp = fmt.Sprintf("%d%02d%02dT%02d%02d%02dZ", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
 		rule.SetAttr("timestamp", &build.StringExpr{Value: timestamp})
 	}


### PR DESCRIPTION
This merge request brings the following changes :

- Rename mirrors attribute to urls attribute
- Add a timestamp attribute
- Add a templating functionality to urls attribute. It allows to support more specific download urls for example (snapshot debian archive or ubuntu launchpad archive)
- change the update code to allow the update of the timestamp attribute when and only when a package is updated
- update the example to be compatible with the above changes
- add to the example section an ubuntu repository and an ubuntu minimal container image
- update the documentation to describe the timestamp, urls and templating changes
- correct a bug in the update_deb_packages go code where an open file was not closed
- correct a bug in the update_deb_packages go code where packages map key and packageSha256 map key were not correctly compared
