### PR TITLE
Use xz instead of gzip version of Package files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/bazelbuild/buildtools v0.0.0-20210227132407-f2aed9ee205d
+	github.com/ulikunitz/xz v0.5.10
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	pault.ag/go/debian v0.11.0
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d/go.mod h1:phT/jsRPBAEqjAibu1BurrabCBNTYiVI+zbmyCZJY6Q=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
+github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 go.starlark.net v0.0.0-20210223155950-e043a3d3c984/go.mod h1:t3mmBBPzAVvK0L0n1drDmrQsJ8FoIx4INCqVMTr/Zo0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/update_deb_packages/update_deb_packages.go
+++ b/update_deb_packages/update_deb_packages.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
 	"flag"
@@ -21,6 +20,7 @@ import (
 	"time"
 
 	"github.com/bazelbuild/buildtools/build"
+	"github.com/ulikunitz/xz"
 	"golang.org/x/crypto/openpgp"
 	"pault.ag/go/debian/control"
 	"pault.ag/go/debian/version"
@@ -194,7 +194,7 @@ func getPackages(arch string, distro string, mirrors []string, components []stri
 				}
 			}
 		}
-		if isAcceptedComponent && strings.HasSuffix(path, "/binary-"+arch+"/Packages.gz") {
+		if isAcceptedComponent && strings.HasSuffix(path, "/binary-"+arch+"/Packages.xz") {
 			tmpPackagesfile, err := ioutil.TempFile("", "Packages")
 			logFatalErr(err)
 			getFileFromMirror(tmpPackagesfile.Name(), path, distro, mirrors)
@@ -208,11 +208,10 @@ func getPackages(arch string, distro string, mirrors []string, components []stri
 			logFatalErr(err)
 			defer handle.Close()
 
-			zipReader, err := gzip.NewReader(handle)
+			xzReader, err := xz.NewReader(handle)
 			logFatalErr(err)
-			defer zipReader.Close()
 
-			content, err := ioutil.ReadAll(zipReader)
+			content, err := ioutil.ReadAll(xzReader)
 			logFatalErr(err)
 			os.Remove(tmpPackagesfile.Name())
 


### PR DESCRIPTION
We encountered a problem where we weren't able to use `buster-backports`, and traced this down to `update_deb_packages` only considering `Package.gz` files. For buster-backports, these files are [only available as `Package.xz`](http://ftp.debian.org/debian/dists/buster-backports/Release).

See: https://wiki.debian.org/DebianRepository/Format

It seems to me like it would be better to switch to download Package files in the xz format. Alternatively, a fallback-mechanism could be implemented.

